### PR TITLE
docs: fix doc examples bug and add behavior notes for some use cases

### DIFF
--- a/src/zipper/list.gleam
+++ b/src/zipper/list.gleam
@@ -118,6 +118,8 @@ pub fn insert_left(zipper: Zipper(a), value: a) -> Zipper(a) {
 }
 
 /// Insert a new value to the right of the current focus value.
+/// If the original zipper is empty, the new value becomes the focus;
+/// otherwise, the original focus remains unchanged.
 ///
 /// ## Examples
 /// ```gleam
@@ -125,6 +127,8 @@ pub fn insert_left(zipper: Zipper(a), value: a) -> Zipper(a) {
 /// |> insert_right(3)
 /// |> to_list
 /// // => [1, 3, 2]
+/// get(zipper)
+/// // => Ok(1)
 /// ```
 pub fn insert_right(zipper: Zipper(a), value: a) -> Zipper(a) {
   case zipper {

--- a/src/zipper/list.gleam
+++ b/src/zipper/list.gleam
@@ -40,7 +40,8 @@ pub opaque type Zipper(a) {
 ///
 /// ## Examples
 /// ```gleam
-/// new() |> to_list
+/// let empty = new()
+/// to_list(empty)
 /// // => []
 /// ```
 pub fn new() -> Zipper(a) {
@@ -51,7 +52,8 @@ pub fn new() -> Zipper(a) {
 ///
 /// ## Examples
 /// ```gleam
-/// from_list([1, 2, 3]) |> get
+/// let zipper = from_list([1, 2, 3])
+/// get(zipper)
 /// // => Ok(1)
 /// ```
 pub fn from_list(list: List(a)) -> Zipper(a) {
@@ -62,7 +64,8 @@ pub fn from_list(list: List(a)) -> Zipper(a) {
 ///
 /// ## Examples
 /// ```gleam
-/// from_list([1, 2, 3]) |> to_list
+/// let zipper = from_list([1, 2, 3])
+/// to_list(zipper)
 /// // => [1, 2, 3]
 /// ```
 pub fn to_list(zipper: Zipper(a)) -> List(a) {
@@ -75,10 +78,12 @@ pub fn to_list(zipper: Zipper(a)) -> List(a) {
 ///
 /// ## Examples
 /// ```gleam
-/// from_list([1, 2, 3]) |> get
+/// let zipper = from_list([1, 2, 3])
+/// get(zipper)
 /// // => Ok(1)
 ///
-/// new() |> get
+/// let empty = new()
+/// get(empty)
 /// // => Error(Nil)
 /// ```
 pub fn get(zipper: Zipper(a)) -> Result(a, Nil) {
@@ -95,19 +100,17 @@ pub fn get(zipper: Zipper(a)) -> Result(a, Nil) {
 ///
 /// ## Examples
 /// ```gleam
-/// from_list([2, 3])
-/// |> insert_left(1)
-/// |> to_list
+/// let zipper =
+///   from_list([2, 3])
+///   |> insert_left(1)
+/// to_list(zipper)
 /// // => [1, 2, 3]
-///
-/// from_list([2, 3])
-/// |> insert_left(1)
-/// |> get
+/// get(zipper)
 /// // => Ok(2)
 ///
-/// from_list([])
-/// |> insert_left(42)
-/// |> get
+/// let empty = from_list([])
+/// let zipper = insert_left(empty, 42)
+/// get(zipper)
 /// // => Ok(42)
 /// ```
 pub fn insert_left(zipper: Zipper(a), value: a) -> Zipper(a) {
@@ -123,9 +126,9 @@ pub fn insert_left(zipper: Zipper(a), value: a) -> Zipper(a) {
 ///
 /// ## Examples
 /// ```gleam
-/// from_list([1, 2])
-/// |> insert_right(3)
-/// |> to_list
+/// let zipper = from_list([1, 2])
+/// let zipper = insert_right(zipper, 3)
+/// to_list(zipper)
 /// // => [1, 3, 2]
 /// get(zipper)
 /// // => Ok(1)
@@ -144,10 +147,10 @@ pub fn insert_right(zipper: Zipper(a), value: a) -> Zipper(a) {
 ///
 /// ## Examples
 /// ```gleam
-/// from_list([1, 2, 3])
-/// |> set(99)
-/// |> result.map(to_list)
-/// // => Ok([99, 2, 3])
+/// let zipper = from_list([1, 2, 3])
+/// let assert Ok(updated) = set(zipper, 99)
+/// to_list(updated)
+/// // => [99, 2, 3]
 /// ```
 pub fn set(zipper: Zipper(a), new_value: a) -> Result(Zipper(a), Nil) {
   case zipper {
@@ -163,10 +166,10 @@ pub fn set(zipper: Zipper(a), new_value: a) -> Result(Zipper(a), Nil) {
 ///
 /// ## Examples
 /// ```gleam
-/// from_list([1, 2, 3])
-/// |> update(fn(x) { x * 2 })
-/// |> result.map(to_list)
-/// // => Ok([2, 2, 3])
+/// let zipper = from_list([1, 2, 3])
+/// let assert Ok(updated) = update(zipper, fn(x) { x * 2 })
+/// to_list(updated)
+/// // => [2, 2, 3]
 /// ```
 pub fn update(zipper: Zipper(a), updater: fn(a) -> a) -> Result(Zipper(a), Nil) {
   case zipper {
@@ -238,8 +241,8 @@ pub fn upsert(zipper: Zipper(a), updater: fn(Option(a)) -> a) -> Zipper(a) {
 /// // => [2, 3]
 ///
 /// // Error when trying to delete the only element
-/// from_list([42])
-/// |> delete()
+/// let single = from_list([42])
+/// delete(single)
 /// // => Error(Nil)
 /// ```
 pub fn delete(zipper: Zipper(a)) -> Result(Zipper(a), Nil) {
@@ -255,10 +258,12 @@ pub fn delete(zipper: Zipper(a)) -> Result(Zipper(a), Nil) {
 ///
 /// ## Examples
 /// ```gleam
-/// new() |> is_empty
+/// let empty = new()
+/// is_empty(empty)
 /// // => True
 ///
-/// from_list([1]) |> is_empty
+/// let zipper = from_list([1])
+/// is_empty(zipper)
 /// // => False
 /// ```
 pub fn is_empty(zipper: Zipper(a)) -> Bool {
@@ -274,7 +279,8 @@ pub fn is_empty(zipper: Zipper(a)) -> Bool {
 ///
 /// ## Examples
 /// ```gleam
-/// from_list([1, 2, 3]) |> is_leftmost
+/// let zipper = from_list([1, 2, 3])
+/// is_leftmost(zipper)
 /// // => True
 ///
 /// let zipper = from_list([1, 2, 3])

--- a/src/zipper/list.gleam
+++ b/src/zipper/list.gleam
@@ -221,9 +221,10 @@ pub fn upsert(zipper: Zipper(a), updater: fn(Option(a)) -> a) -> Zipper(a) {
 /// ## Examples
 /// ```gleam
 /// // Successful deletion with multiple elements
-/// from_list([1, 2, 3])
-/// |> delete()
-/// |> to_list
+/// let zipper =
+///   from_list([1, 2, 3])
+///   |> delete()
+/// to_list(zipper)
 /// // => [2, 3]
 ///
 /// // Error when trying to delete the only element

--- a/src/zipper/list.gleam
+++ b/src/zipper/list.gleam
@@ -186,16 +186,23 @@ pub fn update(zipper: Zipper(a), updater: fn(a) -> a) -> Result(Zipper(a), Nil) 
 ///
 /// ## Examples
 /// ```gleam
+/// let transform = fn(x) {
+///   case x {
+///     Some(value) -> value * 2
+///     None -> 42
+///   }
+/// }
+///
 /// // Update existing value
-/// from_list([1, 2, 3])
-/// |> upsert(fn(Some(x)) { x * 2 })
-/// |> to_list
+/// let zipper = from_list([1, 2, 3])
+/// let zipper = upsert(zipper, transform)
+/// to_list(zipper)
 /// // => [2, 2, 3]
 ///
 /// // Insert when empty
-/// new()
-/// |> upsert(fn(None) { 42 })
-/// |> to_list
+/// let empty = new()
+/// let zipper = upsert(empty, transform)
+/// to_list(zipper)
 /// // => [42]
 /// ```
 pub fn upsert(zipper: Zipper(a), updater: fn(Option(a)) -> a) -> Zipper(a) {
@@ -225,9 +232,8 @@ pub fn upsert(zipper: Zipper(a), updater: fn(Option(a)) -> a) -> Zipper(a) {
 /// ## Examples
 /// ```gleam
 /// // Successful deletion with multiple elements
-/// let zipper =
-///   from_list([1, 2, 3])
-///   |> delete()
+/// let zipper = from_list([1, 2, 3])
+/// let assert Ok(zipper) = delete(zipper)
 /// to_list(zipper)
 /// // => [2, 3]
 ///
@@ -271,7 +277,9 @@ pub fn is_empty(zipper: Zipper(a)) -> Bool {
 /// from_list([1, 2, 3]) |> is_leftmost
 /// // => True
 ///
-/// from_list([1, 2, 3]) |> go_right() |> is_leftmost
+/// let zipper = from_list([1, 2, 3])
+/// let assert Ok(moved) = go_right(zipper)
+/// is_leftmost(moved)
 /// // => False
 /// ```
 pub fn is_leftmost(zipper: Zipper(a)) -> Bool {
@@ -287,11 +295,15 @@ pub fn is_leftmost(zipper: Zipper(a)) -> Bool {
 ///
 /// ## Examples
 /// ```gleam
-/// from_list([1, 2, 3]) |> go_right() |> go_right() |> is_rightmost
-/// // => True
-///
-/// from_list([1, 2, 3]) |> is_rightmost
+/// let zipper = from_list([1, 2, 3])
+/// is_rightmost(zipper)
 /// // => False
+///
+/// let zipper = from_list([1, 2, 3])
+/// let assert Ok(moved) = go_right(zipper)
+/// let assert Ok(rightmost) = go_right(moved)
+/// is_rightmost(rightmost)
+/// // => True
 /// ```
 pub fn is_rightmost(zipper: Zipper(a)) -> Bool {
   case zipper.focus {
@@ -306,10 +318,10 @@ pub fn is_rightmost(zipper: Zipper(a)) -> Bool {
 ///
 /// ## Examples
 /// ```gleam
-/// from_list([1, 2, 3])
-/// |> go_right()
-/// |> go_left()
-/// |> get
+/// let zipper = from_list([1, 2, 3])
+/// let assert Ok(moved) = go_right(zipper)
+/// let assert Ok(returned) = go_left(moved)
+/// get(returned)
 /// // => Ok(1)
 /// ```
 pub fn go_left(zipper: Zipper(a)) -> Result(Zipper(a), Nil) {
@@ -326,9 +338,9 @@ pub fn go_left(zipper: Zipper(a)) -> Result(Zipper(a), Nil) {
 ///
 /// ## Examples
 /// ```gleam
-/// from_list([1, 2, 3])
-/// |> go_right()
-/// |> get
+/// let zipper = from_list([1, 2, 3])
+/// let assert Ok(moved) = go_right(zipper)
+/// get(moved)
 /// // => Ok(2)
 /// ```
 pub fn go_right(zipper: Zipper(a)) -> Result(Zipper(a), Nil) {

--- a/src/zipper/rose_tree.gleam
+++ b/src/zipper/rose_tree.gleam
@@ -421,7 +421,7 @@ pub fn update(zipper: Zipper(a), updater: fn(a) -> a) -> Zipper(a) {
 /// ## Examples
 /// ```gleam
 /// let tree = RoseTree(0, [RoseTree(2, [])])
-/// let zipper = from_standard_tree(tree) |> go_down // focus on 2
+/// let assert Ok(zipper) = from_standard_tree(tree) |> go_down // focus on 2
 ///
 /// let new_sibling = RoseTree(1, [])
 /// let assert Ok(zipper) = insert_left(zipper, new_sibling)
@@ -454,7 +454,7 @@ pub fn insert_left(
 /// ## Examples
 /// ```gleam
 /// let tree = RoseTree(0, [RoseTree(1, [])])
-/// let zipper = from_standard_tree(tree) |> go_down // focus on 1
+/// let assert Ok(zipper) = from_standard_tree(tree) |> go_down // focus on 1
 ///
 /// let new_sibling = RoseTree(2, [])
 /// let assert Ok(zipper) = insert_right(zipper, new_sibling)

--- a/src/zipper/rose_tree.gleam
+++ b/src/zipper/rose_tree.gleam
@@ -7,8 +7,9 @@
 ////
 //// Most navigation and local modification operations are $O(1)$. Going up
 //// the tree is $O(k)$, where $k$ is the number of left siblings of the
-//// current node. Operations that convert from or to a full tree structure
-//// are $O(n)$, where $n$ is the number of nodes in the tree.
+//// current node. Insert children at the last position is $O(d)$, where $d$ is
+//// the number of children. Operations that convert from or to a full tree
+//// structure are $O(n)$, where $n$ is the number of nodes in the tree.
 ////
 //// It supports both a standard `RoseTree` type and can be adapted to work with
 //// any user-defined rose tree structure via an `Adapter`.
@@ -496,6 +497,8 @@ pub fn insert_child(zipper: Zipper(a), tree: RoseTree(a)) -> Zipper(a) {
 }
 
 /// Inserts a new tree as the last child of the current node.
+///
+/// NOTE: This operation is $O(d)$ time complexity, where $d$ is the number of children.
 ///
 /// ## Examples
 /// ```gleam

--- a/src/zipper/tree.gleam
+++ b/src/zipper/tree.gleam
@@ -415,8 +415,8 @@ pub fn set_right(zipper: Zipper(a), right: Tree(a)) -> Result(Zipper(a), Nil) {
 /// let tree = Node(1, Node(2, Leaf, Leaf), Leaf)
 /// let zipper = from_standard_tree(tree)
 ///
-/// let Ok(zipper) = go_left(zipper)
-/// let Ok(zipper) = delete(zipper)
+/// let assert Ok(zipper) = go_left(zipper)
+/// let assert Ok(zipper) = delete(zipper)
 ///
 /// to_standard_tree(zipper)
 /// // => Node(1, Leaf, Leaf)
@@ -483,7 +483,7 @@ pub fn delete_right(zipper: Zipper(a)) -> Result(Zipper(a), Nil) {
 /// is_root(zipper)
 /// // => True
 ///
-/// let Ok(child_zipper) = go_left(zipper)
+/// let assert Ok(child_zipper) = go_left(zipper)
 /// is_root(child_zipper)
 /// // => False
 /// ```
@@ -548,7 +548,7 @@ pub fn go_right(zipper: Zipper(a)) -> Result(Zipper(a), Nil) {
 /// ## Examples
 /// ```gleam
 /// let zipper = from_standard_tree(Node(1, Node(2, Leaf, Leaf), Leaf))
-/// let Ok(child_zipper) = go_left(zipper)
+/// let assert Ok(child_zipper) = go_left(zipper)
 ///
 /// case go_up(child_zipper) {
 ///   Ok(parent_zipper) -> get_value(parent_zipper)

--- a/test/list_test.gleam
+++ b/test/list_test.gleam
@@ -5,7 +5,7 @@ import qcheck
 import zipper/list as zlist
 
 // Main module documentation example
-pub fn doc_example_comprehensive_operations_test() {
+pub fn doc_comprehensive_operations_example_test() {
   let zipper = zlist.from_list([1, 2, 3, 4])
 
   let assert Ok(zipper) = zlist.go_right(zipper)
@@ -17,22 +17,22 @@ pub fn doc_example_comprehensive_operations_test() {
   assert zlist.to_list(zipper) == [1, 42, 99, 4]
 }
 
-pub fn doc_example_new_test() {
+pub fn doc_new_test() {
   let empty = zlist.new()
   assert zlist.to_list(empty) == []
 }
 
-pub fn doc_example_from_list_test() {
+pub fn doc_from_list_test() {
   let zipper = zlist.from_list([1, 2, 3])
   assert zlist.get(zipper) == Ok(1)
 }
 
-pub fn doc_example_to_list_test() {
+pub fn doc_to_list_test() {
   let zipper = zlist.from_list([1, 2, 3])
   assert zlist.to_list(zipper) == [1, 2, 3]
 }
 
-pub fn doc_example_get_test() {
+pub fn doc_get_test() {
   let zipper = zlist.from_list([1, 2, 3])
   assert zlist.get(zipper) == Ok(1)
 
@@ -40,7 +40,7 @@ pub fn doc_example_get_test() {
   assert zlist.get(empty) == Error(Nil)
 }
 
-pub fn doc_example_insert_left_test() {
+pub fn doc_insert_left_test() {
   let zipper =
     zlist.from_list([2, 3])
     |> zlist.insert_left(1)
@@ -52,7 +52,7 @@ pub fn doc_example_insert_left_test() {
   assert zlist.get(zipper) == Ok(42)
 }
 
-pub fn doc_example_insert_right_test() {
+pub fn doc_insert_right_test() {
   let zipper =
     zlist.from_list([1, 2])
     |> zlist.insert_right(3)
@@ -60,19 +60,19 @@ pub fn doc_example_insert_right_test() {
   assert zlist.get(zipper) == Ok(1)
 }
 
-pub fn doc_example_set_test() {
+pub fn doc_set_test() {
   let zipper = zlist.from_list([1, 2, 3])
   let assert Ok(updated) = zlist.set(zipper, 99)
   assert zlist.to_list(updated) == [99, 2, 3]
 }
 
-pub fn doc_example_update_test() {
+pub fn doc_update_test() {
   let zipper = zlist.from_list([1, 2, 3])
   let assert Ok(updated) = zlist.update(zipper, fn(x) { x * 2 })
   assert zlist.to_list(updated) == [2, 2, 3]
 }
 
-pub fn doc_example_upsert_test() {
+pub fn doc_upsert_test() {
   let transform = fn(x) {
     case x {
       Some(value) -> value * 2
@@ -91,7 +91,7 @@ pub fn doc_example_upsert_test() {
   assert zlist.to_list(zipper) == [42]
 }
 
-pub fn doc_example_delete_test() {
+pub fn doc_delete_test() {
   // Successful deletion with multiple elements
   let zipper = zlist.from_list([1, 2, 3])
   let assert Ok(zipper) = zlist.delete(zipper)
@@ -102,7 +102,7 @@ pub fn doc_example_delete_test() {
   assert zlist.delete(single) == Error(Nil)
 }
 
-pub fn doc_example_is_empty_test() {
+pub fn doc_is_empty_test() {
   let empty = zlist.new()
   assert zlist.is_empty(empty) == True
 
@@ -110,7 +110,7 @@ pub fn doc_example_is_empty_test() {
   assert zlist.is_empty(zipper) == False
 }
 
-pub fn doc_example_is_leftmost_test() {
+pub fn doc_is_leftmost_test() {
   let zipper = zlist.from_list([1, 2, 3])
   assert zlist.is_leftmost(zipper) == True
 
@@ -119,7 +119,7 @@ pub fn doc_example_is_leftmost_test() {
   assert zlist.is_leftmost(moved) == False
 }
 
-pub fn doc_example_is_rightmost_test() {
+pub fn doc_is_rightmost_test() {
   let zipper = zlist.from_list([1, 2, 3])
   assert zlist.is_rightmost(zipper) == False
 
@@ -129,14 +129,14 @@ pub fn doc_example_is_rightmost_test() {
   assert zlist.is_rightmost(rightmost) == True
 }
 
-pub fn doc_example_go_left_test() {
+pub fn doc_go_left_test() {
   let zipper = zlist.from_list([1, 2, 3])
   let assert Ok(moved) = zlist.go_right(zipper)
   let assert Ok(returned) = zlist.go_left(moved)
   assert zlist.get(returned) == Ok(1)
 }
 
-pub fn doc_example_go_right_test() {
+pub fn doc_go_right_test() {
   let zipper = zlist.from_list([1, 2, 3])
   let assert Ok(moved) = zlist.go_right(zipper)
   assert zlist.get(moved) == Ok(2)

--- a/test/list_test.gleam
+++ b/test/list_test.gleam
@@ -6,17 +6,140 @@ import zipper/list as zlist
 
 // Main module documentation example
 pub fn doc_example_comprehensive_operations_test() {
-  let z = zlist.from_list([1, 2, 3, 4])
+  let zipper = zlist.from_list([1, 2, 3, 4])
 
-  let assert Ok(new_z) =
-    z
-    |> zlist.go_right()
-    |> result.try(zlist.set(_, 99))
-    |> result.map(zlist.insert_left(_, 42))
-    |> result.try(zlist.go_right)
-    |> result.try(zlist.delete)
+  let assert Ok(zipper) = zlist.go_right(zipper)
+  let assert Ok(zipper) = zlist.set(zipper, 99)
+  let zipper = zlist.insert_left(zipper, 42)
+  let assert Ok(zipper) = zlist.go_right(zipper)
+  let assert Ok(zipper) = zlist.delete(zipper)
 
-  assert new_z |> zlist.to_list == [1, 42, 99, 4]
+  assert zlist.to_list(zipper) == [1, 42, 99, 4]
+}
+
+pub fn doc_example_new_test() {
+  let empty = zlist.new()
+  assert zlist.to_list(empty) == []
+}
+
+pub fn doc_example_from_list_test() {
+  let zipper = zlist.from_list([1, 2, 3])
+  assert zlist.get(zipper) == Ok(1)
+}
+
+pub fn doc_example_to_list_test() {
+  let zipper = zlist.from_list([1, 2, 3])
+  assert zlist.to_list(zipper) == [1, 2, 3]
+}
+
+pub fn doc_example_get_test() {
+  let zipper = zlist.from_list([1, 2, 3])
+  assert zlist.get(zipper) == Ok(1)
+
+  let empty = zlist.new()
+  assert zlist.get(empty) == Error(Nil)
+}
+
+pub fn doc_example_insert_left_test() {
+  let zipper =
+    zlist.from_list([2, 3])
+    |> zlist.insert_left(1)
+  assert zlist.to_list(zipper) == [1, 2, 3]
+  assert zlist.get(zipper) == Ok(2)
+
+  let empty = zlist.from_list([])
+  let zipper = zlist.insert_left(empty, 42)
+  assert zlist.get(zipper) == Ok(42)
+}
+
+pub fn doc_example_insert_right_test() {
+  let zipper =
+    zlist.from_list([1, 2])
+    |> zlist.insert_right(3)
+  assert zlist.to_list(zipper) == [1, 3, 2]
+  assert zlist.get(zipper) == Ok(1)
+}
+
+pub fn doc_example_set_test() {
+  let zipper = zlist.from_list([1, 2, 3])
+  let assert Ok(updated) = zlist.set(zipper, 99)
+  assert zlist.to_list(updated) == [99, 2, 3]
+}
+
+pub fn doc_example_update_test() {
+  let zipper = zlist.from_list([1, 2, 3])
+  let assert Ok(updated) = zlist.update(zipper, fn(x) { x * 2 })
+  assert zlist.to_list(updated) == [2, 2, 3]
+}
+
+pub fn doc_example_upsert_test() {
+  let transform = fn(x) {
+    case x {
+      Some(value) -> value * 2
+      None -> 42
+    }
+  }
+
+  // Update existing value
+  let zipper = zlist.from_list([1, 2, 3])
+  let zipper = zlist.upsert(zipper, transform)
+  assert zlist.to_list(zipper) == [2, 2, 3]
+
+  // Insert when empty
+  let empty = zlist.new()
+  let zipper = zlist.upsert(empty, transform)
+  assert zlist.to_list(zipper) == [42]
+}
+
+pub fn doc_example_delete_test() {
+  // Successful deletion with multiple elements
+  let zipper = zlist.from_list([1, 2, 3])
+  let assert Ok(zipper) = zlist.delete(zipper)
+  assert zlist.to_list(zipper) == [2, 3]
+
+  // Error when trying to delete the only element
+  let single = zlist.from_list([42])
+  assert zlist.delete(single) == Error(Nil)
+}
+
+pub fn doc_example_is_empty_test() {
+  let empty = zlist.new()
+  assert zlist.is_empty(empty) == True
+
+  let zipper = zlist.from_list([1])
+  assert zlist.is_empty(zipper) == False
+}
+
+pub fn doc_example_is_leftmost_test() {
+  let zipper = zlist.from_list([1, 2, 3])
+  assert zlist.is_leftmost(zipper) == True
+
+  let zipper = zlist.from_list([1, 2, 3])
+  let assert Ok(moved) = zlist.go_right(zipper)
+  assert zlist.is_leftmost(moved) == False
+}
+
+pub fn doc_example_is_rightmost_test() {
+  let zipper = zlist.from_list([1, 2, 3])
+  assert zlist.is_rightmost(zipper) == False
+
+  let zipper = zlist.from_list([1, 2, 3])
+  let assert Ok(moved) = zlist.go_right(zipper)
+  let assert Ok(rightmost) = zlist.go_right(moved)
+  assert zlist.is_rightmost(rightmost) == True
+}
+
+pub fn doc_example_go_left_test() {
+  let zipper = zlist.from_list([1, 2, 3])
+  let assert Ok(moved) = zlist.go_right(zipper)
+  let assert Ok(returned) = zlist.go_left(moved)
+  assert zlist.get(returned) == Ok(1)
+}
+
+pub fn doc_example_go_right_test() {
+  let zipper = zlist.from_list([1, 2, 3])
+  let assert Ok(moved) = zlist.go_right(zipper)
+  assert zlist.get(moved) == Ok(2)
 }
 
 //


### PR DESCRIPTION
## Summary

Fixes documentation issues in the zipper module:
- Fix doc examples that pipe `Result`-returning functions without unwrapping
- Document O(n) time complexity of `insert_child_back`

## Changes

- **Fix doc examples piping `Result` without unwrapping** — `go_right`, `go_left`, `go_down` all return `Result(Zipper(a), Nil)`, so piping them raw into the next call won't type-check. Added `let assert Ok(z) = ...` unwrapping in examples.
- **Document `insert_child_back` O(n) complexity** — The function traverses the entire children list to append at the end. Added a complexity note in the docstring.

Closes #4
Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refactored usage examples for clearer, explicit step-by-step code (improved readability)
  * Reformatted and clarified big‑O complexity notes, including an explicit complexity note for child insertion
* **Tests**
  * Added/updated documentation-style example tests covering construction, navigation, mutations, predicates, and conversions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->