### PR TITLE
feat: Add `go_to_root` function to tree and rose_tree modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,23 +1,22 @@
 name: test
 
 on:
-  push:
-    branches:
-      - master
-      - main
-  pull_request:
+    push:
+        branches:
+            - master
+            - main
+    pull_request:
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: "26.0.2"
-          gleam-version: "1.11.0"
-          rebar3-version: "3"
-          # elixir-version: "1.15.4"
-      - run: gleam deps download
-      - run: gleam test
-      - run: gleam format --check src test
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: erlef/setup-beam@v1
+              with:
+                  otp-version: "26.0.2"
+                  gleam-version: "1.17.0"
+                  rebar3-version: "3"
+            - run: gleam deps download
+            - run: gleam test
+            - run: gleam format --check src test

--- a/src/zipper/list.gleam
+++ b/src/zipper/list.gleam
@@ -210,7 +210,10 @@ pub fn set_value(zipper: Zipper(a), new_value: a) -> Result(Zipper(a), Nil) {
 /// to_list(updated)
 /// // => [2, 2, 3]
 /// ```
-pub fn update(zipper: Zipper(a), updater: fn(a) -> a) -> Result(Zipper(a), Nil) {
+pub fn update(
+  zipper: Zipper(a),
+  updater: fn(a) -> a,
+) -> Result(Zipper(a), Nil) {
   case zipper {
     Zipper(_, focus: []) -> Error(Nil)
     Zipper(_, focus: [current, ..rest]) ->

--- a/src/zipper/rose_tree.gleam
+++ b/src/zipper/rose_tree.gleam
@@ -281,6 +281,36 @@ pub fn go_up(zipper: Zipper(a)) -> Result(Zipper(a), Nil) {
   }
 }
 
+/// Moves the focus back to the root of the tree.
+///
+/// This operation is infallible: it always succeeds and returns a new zipper
+/// focused at the root node while preserving the underlying tree structure.
+///
+/// This function's running time depends on the path back to the root. Each
+/// `go_up` step takes $O(k_i)$ time, where $k_i$ is the number of left siblings
+/// at that level, so the total cost is $O(\sum_{i=1}^{d} k_i)$ for a focus at
+/// depth $d$. In the worst case — for example, a tree where every level is
+/// extremely wide on the left — this can be $O(n)$, where $n$ is the number of
+/// nodes in the tree.
+///
+/// ## Examples
+/// ```gleam
+/// let tree = RoseTree(1, [RoseTree(2, [RoseTree(3, [])])])
+/// let zipper = from_standard_tree(tree)
+/// let assert Ok(child_zipper) = go_down(zipper)
+/// assert get_value(child_zipper) == 2
+///
+/// let root_zipper = go_to_root(child_zipper)
+/// assert is_root(root_zipper) == True
+/// assert get_value(root_zipper) == 1
+/// ```
+pub fn go_to_root(zipper: Zipper(a)) -> Zipper(a) {
+  case go_up(zipper) {
+    Ok(zipper) -> go_to_root(zipper)
+    Error(Nil) -> zipper
+  }
+}
+
 /// Moves the focus to the first child of the current node.
 ///
 /// Returns `Ok(zipper)` focused on the first child if it exists.

--- a/src/zipper/rose_tree.gleam
+++ b/src/zipper/rose_tree.gleam
@@ -373,7 +373,10 @@ pub fn get_standard_tree(zipper: Zipper(a)) -> RoseTree(a) {
 ///
 /// // `focused_subtree` is an instance of the custom tree type.
 /// ```
-pub fn get_tree(zipper: Zipper(a), adapter: Adapter(a, user_tree)) -> user_tree {
+pub fn get_tree(
+  zipper: Zipper(a),
+  adapter: Adapter(a, user_tree),
+) -> user_tree {
   let tree = get_standard_tree(zipper)
   adapter.build_node(tree.value, tree.children)
 }

--- a/src/zipper/tree.gleam
+++ b/src/zipper/tree.gleam
@@ -260,7 +260,10 @@ pub fn get_standard_tree(zipper: Zipper(a)) -> Tree(a) {
 ///
 /// // `focused_subtree` is an instance of the custom tree type.
 /// ```
-pub fn get_tree(zipper: Zipper(a), adapter: Adapter(a, user_tree)) -> user_tree {
+pub fn get_tree(
+  zipper: Zipper(a),
+  adapter: Adapter(a, user_tree),
+) -> user_tree {
   get_standard_tree(zipper)
   |> standard_tree_to_user_tree(adapter)
 }
@@ -340,7 +343,10 @@ pub fn set_tree(
 /// }
 /// // => Ok(2)
 /// ```
-pub fn update(zipper: Zipper(a), updater: fn(a) -> a) -> Result(Zipper(a), Nil) {
+pub fn update(
+  zipper: Zipper(a),
+  updater: fn(a) -> a,
+) -> Result(Zipper(a), Nil) {
   case zipper {
     Zipper(_, focus: Leaf) -> Error(Nil)
     Zipper(_, focus: Node(value:, ..) as focus) ->

--- a/src/zipper/tree.gleam
+++ b/src/zipper/tree.gleam
@@ -587,3 +587,27 @@ pub fn go_up(zipper: Zipper(a)) -> Result(Zipper(a), Nil) {
       Ok(Zipper(thread:, focus: Node(value:, left:, right: focus)))
   }
 }
+
+/// Moves the focus back to the root of the tree.
+///
+/// This operation is infallible: it always succeeds and returns a new zipper
+/// focused at the root node while preserving the underlying tree structure.
+///
+/// This function takes $O(d)$ time, where $d$ is the depth of the current focus.
+///
+/// ## Examples
+/// ```gleam
+/// let zipper = from_standard_tree(Node(1, Node(2, Leaf, Leaf), Leaf))
+/// let assert Ok(child_zipper) = go_left(zipper)
+/// assert get_value(child_zipper) == Ok(2)
+///
+/// let root_zipper = go_to_root(child_zipper)
+/// assert is_root(root_zipper) == True
+/// assert get_value(root_zipper) == Ok(1)
+/// ```
+pub fn go_to_root(zipper: Zipper(a)) -> Zipper(a) {
+  case go_up(zipper) {
+    Ok(zipper) -> go_to_root(zipper)
+    Error(Nil) -> zipper
+  }
+}

--- a/test/helpers/generators.gleam
+++ b/test/helpers/generators.gleam
@@ -1,0 +1,32 @@
+import qcheck
+
+/// Creates a recursive generator from a non-recursive seed.
+///
+/// The given function receives a continuation generator and a size hint. It
+/// can call the continuation with a smaller size to build recursive structures
+/// that terminate once the size reaches zero.
+///
+/// ## Examples
+///
+/// ```gleam
+/// fn gen_tree() {
+///   let generator = {
+///     use self, size <- fixpoint
+///     case size {
+///       0 -> qcheck.return(tree.Leaf)
+///       n -> {
+///         use value <- qcheck.bind(qcheck.small_non_negative_int())
+///         use left <- qcheck.map(self(n / 2))
+///         use right <- qcheck.map(self(n / 2))
+///         qcheck.return(tree.Node(value, left, right))
+///       }
+///     }
+///   }
+///   qcheck.sized_from(generator, qcheck.small_non_negative_int())
+/// }
+/// ```
+pub fn fixpoint(
+  f: fn(fn(a) -> qcheck.Generator(b), a) -> qcheck.Generator(b),
+) -> fn(a) -> qcheck.Generator(b) {
+  fn(x) { f(fixpoint(f), x) }
+}

--- a/test/rose_tree_test.gleam
+++ b/test/rose_tree_test.gleam
@@ -1,4 +1,5 @@
 import gleam/list
+import helpers/generators
 import qcheck
 import zipper/rose_tree
 
@@ -456,7 +457,7 @@ pub fn map_focus_round_trip_test() {
 /// stay small and shrinking remains fast.
 fn gen_rose_tree() {
   let generator = {
-    use self, size <- fixpoint
+    use self, size <- generators.fixpoint()
     case size {
       0 ->
         qcheck.map(qcheck.small_non_negative_int(), rose_tree.RoseTree(_, []))
@@ -472,10 +473,4 @@ fn gen_rose_tree() {
   }
 
   qcheck.sized_from(generator, qcheck.small_non_negative_int())
-}
-
-fn fixpoint(
-  f: fn(fn(a) -> qcheck.Generator(b), a) -> qcheck.Generator(b),
-) -> fn(a) -> qcheck.Generator(b) {
-  fn(x) { f(fixpoint(f), x) }
 }

--- a/test/rose_tree_test.gleam
+++ b/test/rose_tree_test.gleam
@@ -120,6 +120,22 @@ pub fn doc_go_right_test() {
   assert rose_tree.get_value(zipper) == 3
 }
 
+// go_to_root examples
+pub fn doc_go_to_root_test() {
+  let tree =
+    rose_tree.RoseTree(1, [
+      rose_tree.RoseTree(2, [rose_tree.RoseTree(3, [])]),
+    ])
+  let zipper = rose_tree.from_standard_tree(tree)
+  let assert Ok(child_zipper) = rose_tree.go_down(zipper)
+  assert rose_tree.get_value(child_zipper) == 2
+
+  let root_zipper = rose_tree.go_to_root(child_zipper)
+  assert rose_tree.is_root(root_zipper) == True
+  assert rose_tree.get_value(root_zipper) == 1
+  assert rose_tree.to_standard_tree(root_zipper) == tree
+}
+
 // go_up examples
 pub fn doc_go_up_test() {
   let tree = rose_tree.RoseTree(1, [rose_tree.RoseTree(2, [])])

--- a/test/tree_test.gleam
+++ b/test/tree_test.gleam
@@ -285,6 +285,24 @@ pub fn doc_go_right_test() {
   assert tree.get_value(zipper) == Ok(3)
 }
 
+// go_to_root examples
+pub fn doc_go_to_root_test() {
+  let zipper =
+    tree.from_standard_tree(tree.Node(
+      1,
+      tree.Node(2, tree.Leaf, tree.Leaf),
+      tree.Leaf,
+    ))
+  let assert Ok(child_zipper) = tree.go_left(zipper)
+  assert tree.get_value(child_zipper) == Ok(2)
+
+  let root_zipper = tree.go_to_root(child_zipper)
+  assert tree.is_root(root_zipper) == True
+  assert tree.get_value(root_zipper) == Ok(1)
+  assert tree.to_standard_tree(root_zipper)
+    == tree.Node(1, tree.Node(2, tree.Leaf, tree.Leaf), tree.Leaf)
+}
+
 // go_up examples
 pub fn doc_go_up_test() {
   let zipper =


### PR DESCRIPTION
## Summary / 概要

Add `go_to_root` function to both `zipper/tree` and `zipper/rose_tree`, allowing users to move the focus back to the root node in a single call.

为 `zipper/tree` 和 `zipper/rose_tree` 新增 `go_to_root` 函数，允许用户一次性将焦点移回根节点。

---

## Motivation / 动机

Both `tree` and `rose_tree` modules already provide `go_up` (move up one level) and `is_root` (check if at root), but users must manually loop `go_up` to return to the root. `go_to_root` provides a convenient, infallible way to navigate directly to the root from any depth.

`tree` 和 `rose_tree` 模块均已提供 `go_up`（向上移动一层）和 `is_root`（检查是否在根节点），但用户需要手动循环调用 `go_up` 才能回到根节点。`go_to_root` 提供了一种便捷且不会失败的方式，从任意深度直接导航到根节点。

---

## Changes / 变更

### `src/zipper/tree.gleam` (+24 lines)

- Added `go_to_root` function with signature `fn(Zipper(a)) -> Zipper(a)`
- Recursive implementation via `go_up`: repeatedly moves up until already at root
- Full documentation with usage examples and time complexity note ($O(d)$ where $d$ is the depth of the current focus)

### `src/zipper/rose_tree.gleam` (+30 lines)

- Added `go_to_root` function with signature `fn(Zipper(a)) -> Zipper(a)`
- Same recursive implementation via `go_up`
- Full documentation with usage examples and time complexity note ($O(\sum_{i=1}^{d} k_i)$, where $k_i$ is the number of left siblings at each level)

### `test/tree_test.gleam` (+18 lines)

- Added `doc_go_to_root_test` doctest verifying:
  - Navigation from child to root
  - `is_root(root_zipper) == True`
  - `get_value(root_zipper)` returns the root value
  - Tree structure is preserved via `to_standard_tree`

### `test/rose_tree_test.gleam` (+16 lines)

- Added `doc_go_to_root_test` doctest verifying:
  - Navigation from child to root
  - `is_root(root_zipper) == True`
  - `get_value(root_zipper)` returns the root value
  - Tree structure is preserved via `to_standard_tree`

---

## Usage Example / 使用示例

### `zipper/tree`

```gleam
let zipper = tree.from_standard_tree(tree.Node(1, tree.Node(2, tree.Leaf, tree.Leaf), tree.Leaf))
let assert Ok(child_zipper) = tree.go_left(zipper)
assert tree.get_value(child_zipper) == Ok(2)

let root_zipper = tree.go_to_root(child_zipper)
assert tree.is_root(root_zipper) == True
assert tree.get_value(root_zipper) == Ok(1)
```

### `zipper/rose_tree`

```gleam
let tree = RoseTree(1, [RoseTree(2, [RoseTree(3, [])])])
let zipper = rose_tree.from_standard_tree(tree)
let assert Ok(child_zipper) = rose_tree.go_down(zipper)
assert rose_tree.get_value(child_zipper) == 2

let root_zipper = rose_tree.go_to_root(child_zipper)
assert rose_tree.is_root(root_zipper) == True
assert rose_tree.get_value(root_zipper) == 1
```

---

## Navigation Functions Comparison / 导航函数对比

| Function / 函数 | tree | rose_tree | Returns / 返回类型 |
|---|---|---|---|
| `go_up` | ✅ | ✅ | `Result(Zipper(a), Nil)` |
| `go_to_root` | ✅ (new) | ✅ (new) | `Zipper(a)` (infallible) |

---

## Checklist / 检查清单

- [x] Add `go_to_root` to `src/zipper/tree.gleam` with documentation
- [x] Add `go_to_root` to `src/zipper/rose_tree.gleam` with documentation
- [x] Add `doc_go_to_root_test` doctest in `test/tree_test.gleam`
- [x] Add `doc_go_to_root_test` doctest in `test/rose_tree_test.gleam`
- [x] Tree structure preserved after `go_to_root` (verified in tests)

Fixes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a simple way to jump a zipper back to the root in both tree types, making it easier to return to the top of a structure from any location.
* **Tests**
  * Added example-style coverage showing root navigation, expected focused values, and conversion back to the original tree structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->