### PR TITLE
feat!: Improve abstraction in adapter callbacks — internal types no longer leak to user code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Adapter API — internal types no longer leak into user callbacks / Adapter API — 内部类型不再泄漏到用户回调中**
+
+  - `zipper/tree`: `build_node` signature changed from `fn(Option(a), #(Option(Tree(a)), Option(Tree(a)))) -> user_tree` to `fn(Option(a), #(Option(user_tree), Option(user_tree))) -> user_tree`. The library now performs recursive conversion internally.
+
+  - `zipper/tree`: `build_node` 签名从 `fn(Option(a), #(Option(Tree(a)), Option(Tree(a)))) -> user_tree` 改为 `fn(Option(a), #(Option(user_tree), Option(user_tree))) -> user_tree`。库现在内部进行递归转换。
+
+  - `zipper/rose_tree`: `get_children` changed from `fn(user_rose_tree) -> List(RoseTree(a))` to `fn(user_rose_tree) -> List(user_rose_tree)`, and `build_node` changed from `fn(a, List(RoseTree(a))) -> user_rose_tree` to `fn(a, List(user_rose_tree)) -> user_rose_tree`. The library now performs recursive conversion internally via `user_tree_to_standard_tree` and `standard_tree_to_user_tree`.
+
+  - `zipper/rose_tree`: `get_children` 从 `fn(user_rose_tree) -> List(RoseTree(a))` 改为 `fn(user_rose_tree) -> List(user_rose_tree)`，`build_node` 从 `fn(a, List(RoseTree(a))) -> user_rose_tree` 改为 `fn(a, List(user_rose_tree)) -> user_rose_tree`。库现在通过 `user_tree_to_standard_tree` 和 `standard_tree_to_user_tree` 内部进行递归转换。
+
+  - Users no longer need to import or handle internal `Tree(a)` / `RoseTree(a)` types in adapter callbacks. / 用户不再需要在 adapter 回调中导入或处理内部 `Tree(a)` / `RoseTree(a)` 类型。
+
 ## [0.1.1] - 2025-09-17
 
 ### Fixed

--- a/src/zipper/rose_tree.gleam
+++ b/src/zipper/rose_tree.gleam
@@ -57,16 +57,14 @@ pub type RoseTree(a) {
 /// and the standard rose tree representation used by the zipper.
 ///
 /// - `get_value`: Extracts the node value from a user tree node.
-/// - `get_children`: Returns a list of standard `RoseTree` children. Note that the
-///   implementer of this function is responsible for converting the user-defined
-///   child nodes into the standard `RoseTree` format.
-/// - `build_node`: Constructs a user tree node from a value and a list of standard
-///   `RoseTree` children.
+/// - `get_children`: Returns a list of user-defined child subtrees.
+/// - `build_node`: Constructs a user tree node from a value and a list of user-defined
+///   child subtrees.
 pub type Adapter(a, user_rose_tree) {
   Adapter(
     get_value: fn(user_rose_tree) -> a,
-    get_children: fn(user_rose_tree) -> List(RoseTree(a)),
-    build_node: fn(a, List(RoseTree(a))) -> user_rose_tree,
+    get_children: fn(user_rose_tree) -> List(user_rose_tree),
+    build_node: fn(a, List(user_rose_tree)) -> user_rose_tree,
   )
 }
 
@@ -154,7 +152,9 @@ pub fn from_tree(
   adapter: Adapter(a, user_tree),
 ) -> Zipper(a) {
   let value = adapter.get_value(users_tree)
-  let children = adapter.get_children(users_tree)
+  let children =
+    adapter.get_children(users_tree)
+    |> list.map(user_tree_to_standard_tree(_, adapter))
   from_standard_tree(RoseTree(value:, children:))
 }
 
@@ -169,7 +169,27 @@ pub fn from_tree(
 /// ```
 pub fn to_tree(zipper: Zipper(a), adapter: Adapter(a, user_tree)) -> user_tree {
   let tree = to_standard_tree(zipper)
-  adapter.build_node(tree.value, tree.children)
+  standard_tree_to_user_tree(tree, adapter)
+}
+
+fn standard_tree_to_user_tree(
+  tree: RoseTree(a),
+  adapter: Adapter(a, user_tree),
+) -> user_tree {
+  let user_children =
+    list.map(tree.children, standard_tree_to_user_tree(_, adapter))
+  adapter.build_node(tree.value, user_children)
+}
+
+fn user_tree_to_standard_tree(
+  tree: user_tree,
+  adapter: Adapter(a, user_tree),
+) -> RoseTree(a) {
+  let value = adapter.get_value(tree)
+  let children =
+    adapter.get_children(tree)
+    |> list.map(user_tree_to_standard_tree(_, adapter))
+  RoseTree(value, children)
 }
 
 /// Moves the focus to the left sibling of the current node.
@@ -378,7 +398,9 @@ pub fn get_tree(
   adapter: Adapter(a, user_tree),
 ) -> user_tree {
   let tree = get_standard_tree(zipper)
-  adapter.build_node(tree.value, tree.children)
+  let user_children =
+    list.map(tree.children, standard_tree_to_user_tree(_, adapter))
+  adapter.build_node(tree.value, user_children)
 }
 
 /// Sets the value of the current focus node.
@@ -427,7 +449,9 @@ pub fn set_tree(
   adapter: Adapter(a, user_tree),
 ) -> Zipper(a) {
   let value = adapter.get_value(tree)
-  let children = adapter.get_children(tree)
+  let children =
+    adapter.get_children(tree)
+    |> list.map(user_tree_to_standard_tree(_, adapter))
   let new_focus = RoseTree(value, children)
   set_standard_tree(zipper, new_focus)
 }

--- a/src/zipper/rose_tree.gleam
+++ b/src/zipper/rose_tree.gleam
@@ -151,11 +151,8 @@ pub fn from_tree(
   users_tree: user_tree,
   adapter: Adapter(a, user_tree),
 ) -> Zipper(a) {
-  let value = adapter.get_value(users_tree)
-  let children =
-    adapter.get_children(users_tree)
-    |> list.map(user_tree_to_standard_tree(_, adapter))
-  from_standard_tree(RoseTree(value:, children:))
+  user_tree_to_standard_tree(users_tree, adapter)
+  |> from_standard_tree
 }
 
 /// Converts a zipper back to a user-defined tree using an adapter.
@@ -398,9 +395,7 @@ pub fn get_tree(
   adapter: Adapter(a, user_tree),
 ) -> user_tree {
   let tree = get_standard_tree(zipper)
-  let user_children =
-    list.map(tree.children, standard_tree_to_user_tree(_, adapter))
-  adapter.build_node(tree.value, user_children)
+  standard_tree_to_user_tree(tree, adapter)
 }
 
 /// Sets the value of the current focus node.
@@ -448,11 +443,7 @@ pub fn set_tree(
   tree: user_tree,
   adapter: Adapter(a, user_tree),
 ) -> Zipper(a) {
-  let value = adapter.get_value(tree)
-  let children =
-    adapter.get_children(tree)
-    |> list.map(user_tree_to_standard_tree(_, adapter))
-  let new_focus = RoseTree(value, children)
+  let new_focus = user_tree_to_standard_tree(tree, adapter)
   set_standard_tree(zipper, new_focus)
 }
 

--- a/src/zipper/tree.gleam
+++ b/src/zipper/tree.gleam
@@ -53,23 +53,24 @@ pub type Tree(a) {
 /// The adapter provides functions to convert between a user-defined tree structure
 /// and the standard binary tree representation used by the zipper.
 ///
-// - `get_value`: Extracts the node value from a user tree node. Returns `None` for
-
+/// - `get_value`: Extracts the node value from a user tree node. Returns `None` for
 ///   leaf nodes, which correspond to the standard tree's `Leaf` constructor.
 /// - `get_children`: Returns a tuple `#(left, right)` where `left` and `right` are
 ///   optional user tree nodes representing the left and right subtrees respectively.
 /// - `build_node`: Constructs a user tree node from an optional value and a tuple
-///   of optional standard tree subtrees. A `None` value corresponds to a leaf node.
+///   of optional user tree subtrees. A `None` value corresponds to a leaf node.
 ///
 /// The mapping between user tree nodes and standard tree nodes is:
 /// - User tree node with `None` value ↔ Standard tree `Leaf`
 /// - User tree node with `Some(value)` ↔ Standard tree `Node(value, left, right)`
-/// - The tuple `#(left, right)` in both directions represents left and right subtrees
+/// - The tuple `#(left, right)` in both directions represents left and right
+///   user tree subtrees
 pub type Adapter(a, user_tree) {
   Adapter(
     get_value: fn(user_tree) -> Option(a),
     get_children: fn(user_tree) -> #(Option(user_tree), Option(user_tree)),
-    build_node: fn(Option(a), #(Option(Tree(a)), Option(Tree(a)))) -> user_tree,
+    build_node: fn(Option(a), #(Option(user_tree), Option(user_tree))) ->
+      user_tree,
   )
 }
 
@@ -195,9 +196,21 @@ fn standard_tree_to_user_tree(
   let #(value, children) = case tree {
     Leaf -> #(None, #(None, None))
     Node(value:, left: Leaf, right: Leaf) -> #(Some(value), #(None, None))
-    Node(value:, left:, right: Leaf) -> #(Some(value), #(Some(left), None))
-    Node(value:, left: Leaf, right:) -> #(Some(value), #(None, Some(right)))
-    Node(value:, left:, right:) -> #(Some(value), #(Some(left), Some(right)))
+    Node(value:, left:, right: Leaf) -> #(
+      Some(value),
+      #(Some(standard_tree_to_user_tree(left, adapter)), None),
+    )
+    Node(value:, left: Leaf, right:) -> #(
+      Some(value),
+      #(None, Some(standard_tree_to_user_tree(right, adapter))),
+    )
+    Node(value:, left:, right:) -> #(
+      Some(value),
+      #(
+        Some(standard_tree_to_user_tree(left, adapter)),
+        Some(standard_tree_to_user_tree(right, adapter)),
+      ),
+    )
   }
   adapter.build_node(value, children)
 }

--- a/test/rose_tree_test.gleam
+++ b/test/rose_tree_test.gleam
@@ -8,34 +8,13 @@ type MyRoseTree(a) {
   MyRoseTree(value: a, children: List(MyRoseTree(a)))
 }
 
-fn standard_to_my_rose_tree(t: rose_tree.RoseTree(a)) -> MyRoseTree(a) {
-  MyRoseTree(
-    value: t.value,
-    children: list.map(t.children, standard_to_my_rose_tree),
-  )
-}
-
-fn my_rose_tree_to_standard(t: MyRoseTree(a)) -> rose_tree.RoseTree(a) {
-  rose_tree.RoseTree(
-    value: t.value,
-    children: list.map(t.children, my_rose_tree_to_standard),
-  )
-}
-
 fn my_rose_tree_adapter() -> rose_tree.Adapter(a, MyRoseTree(a)) {
   let get_value = fn(t: MyRoseTree(a)) -> a { t.value }
 
-  let get_children = fn(t: MyRoseTree(a)) -> List(rose_tree.RoseTree(a)) {
-    list.map(t.children, my_rose_tree_to_standard)
-  }
+  let get_children = fn(t: MyRoseTree(a)) -> List(MyRoseTree(a)) { t.children }
 
-  let build_node = fn(val: a, children: List(rose_tree.RoseTree(a))) -> MyRoseTree(
-    a,
-  ) {
-    MyRoseTree(
-      value: val,
-      children: list.map(children, standard_to_my_rose_tree),
-    )
+  let build_node = fn(val: a, children: List(MyRoseTree(a))) -> MyRoseTree(a) {
+    MyRoseTree(value: val, children:)
   }
 
   rose_tree.Adapter(

--- a/test/tree_test.gleam
+++ b/test/tree_test.gleam
@@ -7,14 +7,6 @@ type MyTree(a) {
   MyNode(a, MyTree(a), MyTree(a))
 }
 
-fn standard_to_my_tree(t: tree.Tree(a)) -> MyTree(a) {
-  case t {
-    tree.Leaf -> MyLeaf
-    tree.Node(v, l, r) ->
-      MyNode(v, standard_to_my_tree(l), standard_to_my_tree(r))
-  }
-}
-
 fn my_tree_adapter() -> tree.Adapter(a, MyTree(a)) {
   let get_value = fn(t: MyTree(a)) -> Option(a) {
     case t {
@@ -42,17 +34,17 @@ fn my_tree_adapter() -> tree.Adapter(a, MyTree(a)) {
 
   let build_node = fn(
     val: Option(a),
-    children: #(Option(tree.Tree(a)), Option(tree.Tree(a))),
+    children: #(Option(MyTree(a)), Option(MyTree(a))),
   ) -> MyTree(a) {
     case val {
       None -> MyLeaf
       Some(v) -> {
         let left = case children {
-          #(Some(l), _) -> standard_to_my_tree(l)
+          #(Some(l), _) -> l
           _ -> MyLeaf
         }
         let right = case children {
-          #(_, Some(r)) -> standard_to_my_tree(r)
+          #(_, Some(r)) -> r
           _ -> MyLeaf
         }
         MyNode(v, left, right)


### PR DESCRIPTION
## Summary / 概要

Refactor `Adapter` callbacks in both `zipper/tree` and `zipper/rose_tree` so that all functions operate purely in user-type terms. The library now handles recursive conversion between user trees and internal standard trees internally.

重构 `zipper/tree` 和 `zipper/rose_tree` 的 `Adapter` 回调，使所有函数完全在用户类型层面操作。库现在内部处理用户树与内部标准树之间的递归转换。

---

## Motivation / 动机

The current adapter design leaks internal types (`Tree(a)`, `RoseTree(a)`) into user-provided callbacks. This forces users to import and understand the library's internal representation, defeating the purpose of the adapter pattern.

当前的 adapter 设计将内部类型（`Tree(a)`、`RoseTree(a)`）泄漏到用户提供的回调中。这强迫用户导入并理解库的内部表示，违背了 adapter 模式的目的。

For example, a rose tree adapter currently requires the user to manually convert between `MyRoseTree` and `RoseTree` in both `get_children` and `build_node`:

例如，玫瑰树 adapter 目前要求用户在 `get_children` 和 `build_node` 中手动转换 `MyRoseTree` 和 `RoseTree`：

```gleam
// Before / 之前
let get_children = fn(t: MyRoseTree(a)) -> List(RoseTree(a)) {
  list.map(t.children, my_rose_tree_to_standard)  // user must convert
}
let build_node = fn(val: a, children: List(RoseTree(a))) -> MyRoseTree(a) {
  MyRoseTree(value: val, children: list.map(children, standard_to_my_rose_tree))  // user must convert
}
```

After this change, the adapter is purely in user-type terms:

改动后，adapter 完全在用户类型层面表达：

```gleam
// After / 之后
let get_children = fn(t: MyRoseTree(a)) -> List(MyRoseTree(a)) {
  t.children  // no conversion needed / 无需转换
}
let build_node = fn(val: a, children: List(MyRoseTree(a))) -> MyRoseTree(a) {
  MyRoseTree(value: val, children:)  // no conversion needed / 无需转换
}
```

---

## Changes / 变更

### `src/zipper/tree.gleam`

- **Adapter type**: `build_node` signature changed from `fn(Option(a), #(Option(Tree(a)), Option(Tree(a)))) -> user_tree` to `fn(Option(a), #(Option(user_tree), Option(user_tree))) -> user_tree`
- **`standard_tree_to_user_tree`**: Now recursively converts `Tree(a)` children to `user_tree` before passing them to `build_node`, rather than passing raw internal trees

### `src/zipper/rose_tree.gleam`

- **Adapter type**: `get_children` changed from `fn(user_rose_tree) -> List(RoseTree(a))` to `fn(user_rose_tree) -> List(user_rose_tree)`
- **Adapter type**: `build_node` changed from `fn(a, List(RoseTree(a))) -> user_rose_tree` to `fn(a, List(user_rose_tree)) -> user_rose_tree`
- **New internal functions**: Added `user_tree_to_standard_tree` and `standard_tree_to_user_tree` for recursive bidirectional conversion
- **`from_tree`**: Now uses internal `user_tree_to_standard_tree` to recursively convert user children
- **`to_tree`**: Now uses internal `standard_tree_to_user_tree` to recursively convert standard children
- **`get_tree`**: Now uses internal `standard_tree_to_user_tree` for recursive conversion
- **`set_tree`**: Now uses internal `user_tree_to_standard_tree` for recursive conversion

### `test/tree_test.gleam`

- Updated `my_tree_adapter` — `build_node` now receives `#(Option(MyTree(a)), Option(MyTree(a)))` instead of `#(Option(Tree(a)), Option(Tree(a)))`
- Removed `standard_to_my_tree` helper function (no longer needed)

### `test/rose_tree_test.gleam`

- Updated `my_rose_tree_adapter` — `get_children` returns `List(MyRoseTree(a))` directly, `build_node` receives `List(MyRoseTree(a))`
- Removed `standard_to_my_rose_tree` and `my_rose_tree_to_standard` helper functions (no longer needed)

### `CHANGELOG.md`

- Added `[Unreleased]` section documenting the breaking adapter API changes

---

## Breaking Change / 破坏性变更

⚠️ This is a **breaking change** (`feat!`). Users with existing custom tree adapters must update their `build_node` and `get_children` signatures.

⚠️ 这是一个**破坏性变更**（`feat!`）。已有自定义树 adapter 的用户必须更新 `build_node` 和 `get_children` 签名。

### Migration Guide / 迁移指南

#### `zipper/tree`

```gleam
// Before / 之前
fn build_node(
  val: Option(a),
  children: #(Option(Tree(a)), Option(Tree(a))),  // internal type
) -> MyTree(a) {
  // user must handle Tree(a) directly
}

// After / 之后
fn build_node(
  val: Option(a),
  children: #(Option(MyTree(a)), Option(MyTree(a))),  // user type
) -> MyTree(a) {
  // children are already in user type
}
```

#### `zipper/rose_tree`

```gleam
// Before / 之前
fn get_children(t: MyRoseTree(a)) -> List(RoseTree(a)) {  // internal type
  list.map(t.children, my_to_standard)
}
fn build_node(val: a, children: List(RoseTree(a))) -> MyRoseTree(a) {  // internal type
  MyRoseTree(value: val, children: list.map(children, standard_to_my))
}

// After / 之后
fn get_children(t: MyRoseTree(a)) -> List(MyRoseTree(a)) {  // user type
  t.children
}
fn build_node(val: a, children: List(MyRoseTree(a))) -> MyRoseTree(a) {  // user type
  MyRoseTree(value: val, children:)
}
```

---

## Benefits / 改进收益

1. **True structural abstraction**: Users no longer need to import or understand `Tree(a)` / `RoseTree(a)` to plug in their own tree types
2. **API consistency**: All three adapter callbacks now operate on the same type vocabulary
3. **Less boilerplate**: Users no longer need to write manual conversion functions between their types and internal types
4. **Improved encapsulation**: Internal representation can evolve without breaking user adapters

1. **真正的结构抽象**：用户无需导入或理解 `Tree(a)` / `RoseTree(a)` 即可接入自己的树类型
2. **API 一致性**：三个 adapter 回调现在操作的是同一套类型词汇
3. **更少的样板代码**：用户不再需要编写自己的类型与内部类型之间的手动转换函数
4. **更好的封装**：内部表示可以演进，而不会破坏用户 adapter

---

## Checklist / 检查清单

- [x] Refactor `zipper/tree.Adapter` — `build_node` uses `Option(user_tree)` for children
- [x] Refactor `zipper/rose_tree.Adapter` — `get_children` returns `List(user_rose_tree)`, `build_node` receives `List(user_rose_tree)`
- [x] Add internal `user_tree_to_standard_tree` / `standard_tree_to_user_tree` helpers for recursive conversion
- [x] Update `from_tree`, `to_tree`, `get_tree`, `set_tree` to use internal recursive conversion
- [x] Update `test/tree_test.gleam` — remove `standard_to_my_tree` helper, simplify `build_node`
- [x] Update `test/rose_tree_test.gleam` — remove conversion helpers, simplify adapter
- [x] Update `CHANGELOG.md` with `[Unreleased]` entry

Fixes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adapter-based tree and rose tree conversions now handle nested child structures automatically, making custom adapters simpler to use.
  * Callback inputs and outputs now use your tree types directly, reducing the need for extra conversion code.

* **Bug Fixes**
  * Improved consistency when converting between standard zipper trees and user-defined tree structures, especially for nested nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->